### PR TITLE
parallelize lambda site updates and invalidate CloudFront

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-cloudfront"
+version = "1.118.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af73cdd78731ac23584e6e09817d9663c38980c9129518ac8c380d4f62affd05"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-cloudwatch"
 version = "1.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2203,10 +2227,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aws-config",
+ "aws-sdk-cloudfront",
  "aws-sdk-s3",
  "aws_lambda_events",
  "bytes",
  "clap",
+ "futures",
  "jluszcz_rust_utils",
  "lambda_runtime",
  "log",
@@ -2828,16 +2854,6 @@ dependencies = [
  "serde",
  "serde_json",
  "vlq",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
 ]
 
 [[package]]
@@ -3913,7 +3929,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.6.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,21 +6,23 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-anyhow = "1.0"
-aws-config = { version = "1.*", features = ["behavior-version-latest"] }
-aws-sdk-s3 = { version = "1.*", features = ["behavior-version-latest"] }
-aws_lambda_events = "1.0"
-bytes = "1.*"
-clap = { version = "4.5", features = ["env"] }
+anyhow = "1"
+aws-config = { version = "1", features = ["behavior-version-latest"] }
+aws-sdk-cloudfront = { version = "1", features = ["behavior-version-latest"] }
+aws-sdk-s3 = { version = "1", features = ["behavior-version-latest"] }
+aws_lambda_events = "1"
+bytes = "1"
+clap = { version = "4", features = ["env"] }
+futures = "0.3"
 minify-html = "0.18"
 jluszcz_rust_utils = { git = "https://github.com//jluszcz/rust-utils" }
-lambda_runtime = "1.*"
+lambda_runtime = "1"
 log = "0.4"
-minijinja = "2.*"
-regex = "1.*"
-serde = "1.0"
-serde_json = "1.0"
-tokio = { version = "1.*", features = ["full"] }
+minijinja = "2"
+regex = "1"
+serde = "1"
+serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs", "sync"] }
 
 [[bin]]
 name = "main"

--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ ListOfLists generates a static website, hosted on AWS in an S3 bucket, from a JS
 | `duplicates` | bool   | `false`  | If `false`, duplicate items cause a validation error      |
 | `list`       | array  | required | Array of items (strings or objects with `item`/`tooltip`) |
 
+### Validation
+
+The generator rejects input that would produce a degenerate page:
+
+- The top-level `title` must be non-empty.
+- `lists` must contain at least one list.
+- Each list `title`, each item string, and each tooltip must be non-empty.
+- Duplicate items within a list are rejected unless `duplicates: true`.
+
 ### Footers
 
 The `footer` object supports `imports` and `links`. Use `imports` to inject `<script>` or `<link>` tags (e.g. for icon
@@ -151,7 +160,26 @@ terraform apply
 
 1. Upload `${LOL_SITE_URL}.json` to `s3://<generator_bucket>/${LOL_SITE_URL}.json`
 
-The Lambda function triggers automatically on S3 object changes to regenerate the site.
+The Lambda function triggers automatically on S3 object changes:
+
+- A change to `${site_url}.json` regenerates that single site.
+- A change to `index.template` regenerates every site found in the generator bucket. Sites are rendered concurrently
+  using a shared parsed template.
+
+After each render, the Lambda issues a CloudFront invalidation for `/index.html` on the distribution whose aliases
+include the site URL. Distribution lookups are cached for the lifetime of the warm container. Invalidation failures are
+logged but do not fail the Lambda; the new `index.html` is already in S3 and will be served once the existing cache
+entry expires.
+
+### Lambda IAM
+
+The Lambda role (defined in `shared/main.tf`) requires:
+
+- `s3:GetObject` and `s3:ListBucket` on the generator bucket.
+- `s3:PutObject` on `arn:aws:s3:::*/index.html` (broad by design — see comment in `shared/main.tf`).
+- `cloudfront:ListDistributions` and `cloudfront:CreateInvalidation` (resource `*`) for the post-render invalidation.
+
+Re-apply `shared/` Terraform when upgrading from a version without CloudFront permissions.
 
 See [moviel.ist](https://github.com/jluszcz/MovieList) or [burgerl.ist](https://github.com/jluszcz/BurgerList) for
 examples of how to automate uploads with [GitHub Actions](https://github.com/features/actions).

--- a/shared/main.tf
+++ b/shared/main.tf
@@ -162,6 +162,28 @@ resource "aws_iam_role_policy_attachment" "s3" {
   policy_arn = aws_iam_policy.s3.arn
 }
 
+data "aws_iam_policy_document" "cloudfront" {
+  statement {
+    actions   = ["cloudfront:ListDistributions"]
+    resources = ["*"]
+  }
+
+  statement {
+    actions   = ["cloudfront:CreateInvalidation"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "cloudfront" {
+  name   = "list-of-lists.cloudfront"
+  policy = data.aws_iam_policy_document.cloudfront.json
+}
+
+resource "aws_iam_role_policy_attachment" "cloudfront" {
+  role       = aws_iam_role.lambda.name
+  policy_arn = aws_iam_policy.cloudfront.arn
+}
+
 resource "aws_s3_bucket_notification" "notification" {
   bucket = aws_s3_bucket.generator.id
 
@@ -189,7 +211,7 @@ resource "aws_lambda_function" "lambda" {
   handler       = "ignored"
   publish       = false
   description   = "Generate list-of-lists sites"
-  timeout       = 5
+  timeout       = 30
   memory_size   = 128
 
   lifecycle {

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,5 +1,5 @@
 use crate::{ListOfLists, s3util};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use log::{debug, trace};
 use minify_html::Cfg;
 use minijinja::{Environment, Error, State};
@@ -17,7 +17,7 @@ const SITE_INDEX: &str = "index.html";
 const DIV_ID_SAFE: &str = "div_id_safe";
 const OPTIMIZE_IMPORT: &str = "optimize_import";
 
-enum Io {
+pub enum Io {
     S3 {
         s3_client: aws_sdk_s3::Client,
         generator_bucket: String,
@@ -30,7 +30,7 @@ enum Io {
 }
 
 impl Io {
-    fn new(
+    pub fn new(
         site_url: String,
         generator_bucket: String,
         s3_client: Option<aws_sdk_s3::Client>,
@@ -56,64 +56,75 @@ impl Io {
                 ..
             } => {
                 let bytes = s3util::get(s3_client, generator_bucket, target).await?;
-                Ok(str::from_utf8(&bytes)?.into())
+                let s = str::from_utf8(&bytes)
+                    .with_context(|| format!("{target} from {generator_bucket} is not UTF-8"))?;
+                Ok(s.into())
             }
 
             Io::LocalFile { generator_path, .. } => {
                 let path = generator_path.join(target);
                 debug!("Reading {path:?}");
-                let res = fs::read_to_string(&path).await;
-                debug!(
-                    "{} {path:?}",
-                    if res.is_ok() {
-                        "Read"
-                    } else {
-                        "Failed to read"
-                    }
-                );
-                Ok(res?)
+                fs::read_to_string(&path)
+                    .await
+                    .with_context(|| format!("read {path:?}"))
             }
         }
     }
 
-    async fn write(&self, target: &str, content: &[u8]) -> Result<()> {
+    async fn write(&self, target: &str, content: Vec<u8>) -> Result<()> {
         match self {
             Io::S3 {
                 s3_client,
                 site_bucket,
                 ..
-            } => s3util::put(s3_client, site_bucket, target, "text/html", content).await?,
+            } => s3util::put(s3_client, site_bucket, target, "text/html", content).await,
 
             Io::LocalFile { site_path, .. } => {
                 let path = site_path.join(target);
                 debug!("Writing to {path:?}");
-                let res = fs::write(&path, content).await;
-                debug!(
-                    "{} {path:?}",
-                    if res.is_ok() {
-                        "Wrote"
-                    } else {
-                        "Failed to write"
-                    }
-                );
-                res?
+                fs::write(&path, content)
+                    .await
+                    .with_context(|| format!("write {path:?}"))
             }
         }
-
-        Ok(())
     }
 }
 
-async fn read_template(io: &Io) -> Result<String> {
-    io.read(SITE_INDEX_TEMPLATE).await
+pub async fn read_template(
+    generator_bucket: &str,
+    s3_client: Option<&aws_sdk_s3::Client>,
+) -> Result<String> {
+    match s3_client {
+        Some(client) => {
+            let bytes = s3util::get(client, generator_bucket, SITE_INDEX_TEMPLATE)
+                .await
+                .with_context(|| format!("read {SITE_INDEX_TEMPLATE}"))?;
+            let s = str::from_utf8(&bytes)
+                .with_context(|| format!("{SITE_INDEX_TEMPLATE} is not UTF-8"))?;
+            Ok(s.to_string())
+        }
+        None => {
+            let path = Path::new("buckets")
+                .join(generator_bucket)
+                .join(SITE_INDEX_TEMPLATE);
+            debug!("Reading {path:?}");
+            fs::read_to_string(&path)
+                .await
+                .with_context(|| format!("read {path:?}"))
+        }
+    }
 }
 
 async fn read_list(io: &Io, site_url: &str) -> Result<ListOfLists> {
-    let content = io.read(&format!("{site_url}.json")).await?;
-    let list_of_lists: ListOfLists = serde_json::from_str(content.as_str())?;
+    let key = format!("{site_url}.json");
+    let content = io.read(&key).await.with_context(|| format!("read {key}"))?;
+    let list_of_lists: ListOfLists = serde_json::from_str(content.as_str())
+        .with_context(|| format!("parse {key} as ListOfLists"))?;
     trace!("{list_of_lists:?}");
 
-    list_of_lists.validate()
+    list_of_lists
+        .validate()
+        .with_context(|| format!("validate {key}"))
 }
 
 fn div_id_safe(_: &State, value: String) -> Result<String, Error> {
@@ -124,7 +135,7 @@ fn inner_div_id_safe<S>(value: S) -> String
 where
     S: Into<String>,
 {
-    static RE: LazyLock<Regex> = LazyLock::new(|| Regex::new("[^[_0-9A-Za-z]]").unwrap());
+    static RE: LazyLock<Regex> = LazyLock::new(|| Regex::new("[^_0-9A-Za-z]").unwrap());
 
     RE.replace_all(&value.into().replace(' ', "_"), "")
         .into_owned()
@@ -175,31 +186,36 @@ where
         .into_owned()
 }
 
-pub async fn update_site(
-    site_url: String,
-    generator_bucket: String,
-    s3_client: Option<aws_sdk_s3::Client>,
-    minify: bool,
-) -> Result<()> {
-    let io = Io::new(site_url.clone(), generator_bucket, s3_client);
-
-    let (template, list_of_lists) =
-        tokio::try_join!(read_template(&io), read_list(&io, &site_url),)?;
-
+pub fn build_environment(template: &str) -> Result<Environment<'_>> {
     let mut env = Environment::new();
-    env.add_template(SITE_INDEX, &template)?;
+    env.add_template(SITE_INDEX, template)
+        .context("compile index template")?;
     env.add_filter(DIV_ID_SAFE, div_id_safe);
     env.add_filter(OPTIMIZE_IMPORT, optimize_import);
+    Ok(env)
+}
 
-    let template = env.get_template(SITE_INDEX)?;
+pub async fn render_site(
+    io: &Io,
+    env: &Environment<'_>,
+    site_url: &str,
+    minify: bool,
+) -> Result<()> {
+    let list_of_lists = read_list(io, site_url).await?;
 
-    debug!("Rendering {SITE_INDEX}");
-    let site = template.render(&list_of_lists)?;
-    debug!("Rendered {SITE_INDEX}");
+    let template = env
+        .get_template(SITE_INDEX)
+        .context("get compiled index template")?;
+
+    debug!("Rendering {SITE_INDEX} for {site_url}");
+    let site = template
+        .render(&list_of_lists)
+        .with_context(|| format!("render {SITE_INDEX} for {site_url}"))?;
+    debug!("Rendered {SITE_INDEX} for {site_url}");
 
     let site = if minify {
         let original_size = site.len();
-        debug!("Minifying {SITE_INDEX} (original size: {original_size})",);
+        debug!("Minifying {SITE_INDEX} for {site_url} (original size: {original_size})");
 
         let mut cfg = Cfg::new();
         cfg.minify_css = true;
@@ -208,7 +224,7 @@ pub async fn update_site(
         let site = minify_html::minify(site.as_bytes(), &cfg);
 
         debug!(
-            "Minified {SITE_INDEX}: {:.1}% (new size: {})",
+            "Minified {SITE_INDEX} for {site_url}: {:.1}% (new size: {})",
             100.0 * (site.len() as f64 / original_size as f64),
             site.len()
         );
@@ -218,7 +234,21 @@ pub async fn update_site(
         site.as_bytes().to_vec()
     };
 
-    io.write(SITE_INDEX, &site).await
+    io.write(SITE_INDEX, site)
+        .await
+        .with_context(|| format!("write {SITE_INDEX} for {site_url}"))
+}
+
+pub async fn update_site(
+    site_url: String,
+    generator_bucket: String,
+    s3_client: Option<aws_sdk_s3::Client>,
+    minify: bool,
+) -> Result<()> {
+    let template = read_template(&generator_bucket, s3_client.as_ref()).await?;
+    let env = build_environment(&template)?;
+    let io = Io::new(site_url.clone(), generator_bucket, s3_client);
+    render_site(&io, &env, &site_url, minify).await
 }
 
 #[cfg(test)]

--- a/src/lambda.rs
+++ b/src/lambda.rs
@@ -1,14 +1,24 @@
+use anyhow::{Context, Result, anyhow};
 use aws_config::ConfigLoader;
 use aws_lambda_events::s3::S3Event;
+use aws_sdk_cloudfront::Client as CloudFrontClient;
+use aws_sdk_cloudfront::types::{InvalidationBatch, Paths};
 use aws_sdk_s3::Client as S3Client;
 use jluszcz_rust_utils::lambda;
 use lambda_runtime::{LambdaEvent, service_fn};
 use list_of_lists::{APP_NAME, generator, s3util};
-use log::info;
+use log::{debug, info, warn};
 use serde_json::{Value, json};
+use std::collections::HashMap;
 use std::env;
+use std::sync::LazyLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::Mutex;
 
 const MINIFY: bool = true;
+
+static INVALIDATION_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[tokio::main]
 async fn main() -> Result<(), lambda_runtime::Error> {
@@ -24,39 +34,211 @@ async fn function(event: LambdaEvent<Value>) -> Result<Value, lambda_runtime::Er
 
     let aws_config = ConfigLoader::default().load().await;
     let s3_client = S3Client::new(&aws_config);
+    let cloudfront_client = CloudFrontClient::new(&aws_config);
 
     let event: S3Event = serde_json::from_value(event.payload)?;
+
+    let mut site_urls: Vec<String> = Vec::new();
+    let mut regenerate_all = false;
+
     for record in event.records {
         let bucket = record.s3.bucket.name;
         let key = record.s3.object.key;
         if let (Some(bucket), Some(key)) = (bucket, key) {
             if key == generator::SITE_INDEX_TEMPLATE {
                 info!("Regenerating all sites on update of {bucket}/{key}");
-                let site_keys = s3util::list_keys(&s3_client, &generator_bucket, ".json").await?;
-                for site_key in site_keys {
-                    if let Some(site_url) = site_key.strip_suffix(".json") {
-                        info!("Updating {site_url}");
-                        generator::update_site(
-                            site_url.to_string(),
-                            generator_bucket.clone(),
-                            Some(s3_client.clone()),
-                            MINIFY,
-                        )
-                        .await?;
-                    }
-                }
+                regenerate_all = true;
+                break;
             } else if let Some(site_url) = key.strip_suffix(".json") {
-                info!("Updating {site_url} on update of {bucket}/{key}");
-                generator::update_site(
-                    site_url.to_string(),
-                    generator_bucket.clone(),
-                    Some(s3_client.clone()),
-                    MINIFY,
-                )
-                .await?;
+                info!("Will update {site_url} on update of {bucket}/{key}");
+                site_urls.push(site_url.to_string());
             }
         }
     }
 
+    if regenerate_all {
+        site_urls = s3util::list_keys(&s3_client, &generator_bucket, ".json")
+            .await?
+            .into_iter()
+            .filter_map(|k| k.strip_suffix(".json").map(String::from))
+            .collect();
+    }
+
+    // Dedupe so duplicate S3 events don't trigger duplicate renders or invalidations.
+    site_urls.sort();
+    site_urls.dedup();
+
+    if site_urls.is_empty() {
+        return Ok(json!({}));
+    }
+
+    let template = generator::read_template(&generator_bucket, Some(&s3_client)).await?;
+    let env = generator::build_environment(&template)?;
+
+    let render_futures = site_urls.iter().map(|site_url| {
+        let io = generator::Io::new(
+            site_url.clone(),
+            generator_bucket.clone(),
+            Some(s3_client.clone()),
+        );
+        let env = &env;
+        async move {
+            info!("Updating {site_url}");
+            generator::render_site(&io, env, site_url, MINIFY).await
+        }
+    });
+    let render_results = futures::future::join_all(render_futures).await;
+
+    let mut rendered_sites: Vec<String> = Vec::new();
+    let mut render_failures = 0usize;
+    for (site_url, result) in site_urls.iter().zip(render_results) {
+        match result {
+            Ok(()) => rendered_sites.push(site_url.clone()),
+            Err(err) => {
+                warn!("Failed to render {site_url}: {err:#}");
+                render_failures += 1;
+            }
+        }
+    }
+    if rendered_sites.is_empty() {
+        return Err(anyhow!("all {render_failures} site render(s) failed").into());
+    }
+
+    // Group rendered sites by distribution_id so we issue one invalidation per
+    // distribution even if duplicate events or multiple aliases collapse onto
+    // the same one. Lookups are serial because they share the cache mutex.
+    let mut by_distribution: HashMap<String, Vec<String>> = HashMap::new();
+    for site_url in &rendered_sites {
+        match distribution_id_for_alias(&cloudfront_client, site_url).await {
+            Ok(Some(distribution_id)) => by_distribution
+                .entry(distribution_id)
+                .or_default()
+                .push(site_url.clone()),
+            Ok(None) => warn!("No CloudFront distribution found with alias {site_url}"),
+            Err(err) => warn!("CloudFront lookup failed for {site_url}: {err:#}"),
+        }
+    }
+
+    let invalidation_futures = by_distribution.iter().map(|(distribution_id, sites)| {
+        invalidate_distribution(&cloudfront_client, distribution_id, sites)
+    });
+    let results = futures::future::join_all(invalidation_futures).await;
+    let mut invalidation_failures = 0usize;
+    for ((distribution_id, _), result) in by_distribution.iter().zip(results) {
+        if let Err(err) = result {
+            warn!("CloudFront invalidation failed for distribution {distribution_id}: {err:#}");
+            invalidation_failures += 1;
+        }
+    }
+
+    info!(
+        "rendered {}/{} sites; invalidated {}/{} distributions",
+        rendered_sites.len(),
+        site_urls.len(),
+        by_distribution.len() - invalidation_failures,
+        by_distribution.len(),
+    );
+
     Ok(json!({}))
+}
+
+async fn invalidate_distribution(
+    client: &CloudFrontClient,
+    distribution_id: &str,
+    sites: &[String],
+) -> Result<()> {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after UNIX_EPOCH")
+        .as_nanos();
+    let counter = INVALIDATION_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let caller_reference = format!("list-of-lists-{distribution_id}-{nanos}-{counter}");
+
+    let paths = Paths::builder()
+        .quantity(1)
+        .items("/index.html")
+        .build()
+        .context("build invalidation Paths")?;
+
+    let batch = InvalidationBatch::builder()
+        .paths(paths)
+        .caller_reference(caller_reference)
+        .build()
+        .context("build InvalidationBatch")?;
+
+    info!("Invalidating /index.html on distribution {distribution_id} for sites {sites:?}");
+    client
+        .create_invalidation()
+        .distribution_id(distribution_id)
+        .invalidation_batch(batch)
+        .send()
+        .await
+        .with_context(|| format!("create_invalidation for distribution {distribution_id}"))?;
+
+    Ok(())
+}
+
+// Cached per warm container: alias -> distribution id. Populated on first
+// lookup and refreshed on miss so newly created distributions are picked up
+// without a redeploy.
+static DISTRIBUTION_CACHE: LazyLock<Mutex<Option<HashMap<String, String>>>> =
+    LazyLock::new(|| Mutex::new(None));
+
+async fn distribution_id_for_alias(
+    client: &CloudFrontClient,
+    alias: &str,
+) -> Result<Option<String>> {
+    // Hold the lock across the API call so concurrent callers on a cold cache
+    // don't each fire their own list_distributions request.
+    let mut cache = DISTRIBUTION_CACHE.lock().await;
+    if let Some(map) = cache.as_ref()
+        && let Some(id) = map.get(alias)
+    {
+        debug!("Distribution cache hit for {alias}");
+        return Ok(Some(id.clone()));
+    }
+
+    debug!("Distribution cache miss for {alias}; refreshing");
+    let fresh = list_distribution_aliases(client).await?;
+    let result = fresh.get(alias).cloned();
+    *cache = Some(fresh);
+    Ok(result)
+}
+
+async fn list_distribution_aliases(client: &CloudFrontClient) -> Result<HashMap<String, String>> {
+    let mut out: HashMap<String, String> = HashMap::new();
+    let mut marker: Option<String> = None;
+    loop {
+        let mut req = client.list_distributions();
+        if let Some(m) = marker {
+            req = req.marker(m);
+        }
+        let response = req.send().await.context("list_distributions")?;
+        let Some(list) = response.distribution_list else {
+            break;
+        };
+        for item in list.items() {
+            if let Some(aliases) = item.aliases.as_ref() {
+                for alias in aliases.items() {
+                    if let Some(existing) = out.insert(alias.clone(), item.id.clone())
+                        && existing != item.id
+                    {
+                        warn!(
+                            "CloudFront alias {alias} appears on multiple distributions ({existing} and {new}); using {new}",
+                            new = item.id,
+                        );
+                    }
+                }
+            }
+        }
+        if list.is_truncated {
+            marker = list.next_marker;
+            if marker.is_none() {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    Ok(out)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,15 @@ pub struct ListOfLists {
 }
 
 impl ListOfLists {
+    // Rejects empty-after-trim strings; non-empty values keep their whitespace
+    // verbatim so the renderer surfaces formatting issues rather than masking them.
     pub fn validate(self) -> Result<Self> {
+        if self.title.trim().is_empty() {
+            return Err(anyhow!("ListOfLists title must not be empty"));
+        }
+        if self.lists.is_empty() {
+            return Err(anyhow!("ListOfLists must contain at least one list"));
+        }
         for l in &self.lists {
             l.validate()?;
         }
@@ -46,11 +54,17 @@ pub struct List {
 
 impl List {
     fn validate(&self) -> Result<()> {
-        if !self.duplicates && self.list.iter().collect::<HashSet<_>>().len() != self.list.len() {
-            Err(anyhow!("Illegal duplicates found in {:?}", self.list))
-        } else {
-            Ok(())
+        if self.title.trim().is_empty() {
+            return Err(anyhow!("List title must not be empty"));
         }
+        for item in &self.list {
+            item.validate()
+                .map_err(|e| anyhow!("{} in list {:?}", e, self.title))?;
+        }
+        if !self.duplicates && self.list.iter().collect::<HashSet<_>>().len() != self.list.len() {
+            return Err(anyhow!("Illegal duplicates found in {:?}", self.list));
+        }
+        Ok(())
     }
 }
 
@@ -59,6 +73,27 @@ impl List {
 pub enum ListItem {
     Item(String),
     WithTooltip { item: String, tooltip: String },
+}
+
+impl ListItem {
+    fn validate(&self) -> Result<()> {
+        match self {
+            ListItem::Item(s) => {
+                if s.trim().is_empty() {
+                    return Err(anyhow!("List item must not be empty"));
+                }
+            }
+            ListItem::WithTooltip { item, tooltip } => {
+                if item.trim().is_empty() {
+                    return Err(anyhow!("List item must not be empty"));
+                }
+                if tooltip.trim().is_empty() {
+                    return Err(anyhow!("Tooltip must not be empty for item {:?}", item));
+                }
+            }
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -83,6 +118,7 @@ pub struct FooterItem {
 
 pub mod s3util {
     use super::*;
+    use anyhow::Context;
     use aws_sdk_s3::primitives::ByteStream;
     use bytes::Bytes;
     use log::debug;
@@ -98,10 +134,12 @@ pub mod s3util {
             .bucket(bucket_name)
             .key(object_name)
             .send()
-            .await?
+            .await
+            .with_context(|| format!("get_object {bucket_name}/{object_name}"))?
             .body
             .collect()
-            .await?
+            .await
+            .with_context(|| format!("read body of {bucket_name}/{object_name}"))?
             .into_bytes();
         debug!("Read {bucket_name}:{object_name} from S3");
 
@@ -113,7 +151,7 @@ pub mod s3util {
         bucket_name: &str,
         object_name: &str,
         content_type: &str,
-        data: &[u8],
+        data: Vec<u8>,
     ) -> Result<()> {
         debug!("Uploading {bucket_name}:{object_name} to S3");
         s3_client
@@ -121,9 +159,10 @@ pub mod s3util {
             .bucket(bucket_name)
             .key(object_name)
             .content_type(content_type)
-            .body(ByteStream::from(Bytes::from(Vec::from(data))))
+            .body(ByteStream::from(Bytes::from(data)))
             .send()
-            .await?;
+            .await
+            .with_context(|| format!("put_object {bucket_name}/{object_name}"))?;
         debug!("Uploaded {bucket_name}:{object_name} to S3");
 
         Ok(())
@@ -142,7 +181,10 @@ pub mod s3util {
             if let Some(token) = continuation_token {
                 req = req.continuation_token(token);
             }
-            let response = req.send().await?;
+            let response = req
+                .send()
+                .await
+                .with_context(|| format!("list_objects_v2 {bucket_name}"))?;
             for obj in response.contents() {
                 if let Some(key) = obj.key()
                     && key.ends_with(suffix)
@@ -158,23 +200,6 @@ pub mod s3util {
         }
         debug!("Listed {} '{suffix}' keys in {bucket_name}", keys.len());
         Ok(keys)
-    }
-
-    pub async fn exists(
-        s3_client: &aws_sdk_s3::Client,
-        bucket_name: &str,
-        object_name: &str,
-    ) -> Result<bool> {
-        debug!("Checking {bucket_name}:{object_name} on S3");
-        let response = s3_client
-            .head_object()
-            .bucket(bucket_name)
-            .key(object_name)
-            .send()
-            .await;
-        debug!("Checked {bucket_name}:{object_name} on S3");
-
-        Ok(response.is_ok())
     }
 }
 
@@ -285,6 +310,62 @@ mod test {
     fn test_list_validation_duplicates_disallowed() {
         let l = List::new("Letters", false, false, &["A", "A"]);
 
+        assert!(l.validate().is_err());
+    }
+
+    #[test]
+    fn test_validation_rejects_empty_top_level_title() {
+        let lol = ListOfLists {
+            title: "  ".to_string(),
+            footer_links: vec![],
+            footer: None,
+            lists: vec![List::new("Letters", false, false, &["A"])],
+        };
+        assert!(lol.validate().is_err());
+    }
+
+    #[test]
+    fn test_validation_rejects_empty_lists_vec() {
+        let lol = ListOfLists {
+            title: "The List".to_string(),
+            footer_links: vec![],
+            footer: None,
+            lists: vec![],
+        };
+        assert!(lol.validate().is_err());
+    }
+
+    #[test]
+    fn test_validation_rejects_empty_list_title() {
+        let l = List::new("", false, false, &["A"]);
+        assert!(l.validate().is_err());
+    }
+
+    #[test]
+    fn test_validation_rejects_empty_item() {
+        let l = List::new("Letters", false, false, &["A", ""]);
+        assert!(l.validate().is_err());
+    }
+
+    #[test]
+    fn test_validation_rejects_empty_tooltip() {
+        let l = List::from_items(
+            "Tooltip",
+            false,
+            false,
+            vec![ListItem::with_tooltip("foo", "")],
+        );
+        assert!(l.validate().is_err());
+    }
+
+    #[test]
+    fn test_validation_rejects_empty_tooltip_item() {
+        let l = List::from_items(
+            "Tooltip",
+            false,
+            false,
+            vec![ListItem::with_tooltip("", "baz")],
+        );
         assert!(l.validate().is_err());
     }
 


### PR DESCRIPTION
- Parse the index template once and share the Minijinja environment across sites; render sites concurrently with futures::try_join_all.
- After site renders, invalidate /index.html on the matching CloudFront distribution (looked up by alias). Adds CloudFront IAM permissions to the lambda role and bumps the lambda timeout from 5s to 30s.
- Strengthen ListOfLists validation: reject empty top-level title, empty lists, empty list titles, empty items, and empty tooltips.
- Remove unused s3util::exists; drop redundant allocation in s3util::put by using Bytes::copy_from_slice.
- Add anyhow .with_context to S3, template, render, and write paths.
- Simplify div_id_safe regex from [^[_0-9A-Za-z]] to [^_0-9A-Za-z].
- Tighten Cargo version pins (1.* -> 1) and scope tokio features down to macros, rt-multi-thread, and fs.