### PR TITLE
Address web standards review findings and rust cleanups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ has two main execution modes:
 **Template (`index.template`)**
 
 - Minijinja template that renders the full HTML page for a site
-- Receives `title`, `lists`, and optional `footer`/`footer_links` variables from the generator
+- Receives `title`, `lists`, `site_url`, and optional `description`/`footer`/`footer_links` variables from the generator
 - Iterates over non-hidden lists to build Bootstrap tab navigation and list content
 - Supports two item types: plain strings and tooltip objects (`{ item, tooltip }`)
 - When running locally, the generated `index.html` is written to `buckets/{site_url}/index.html` (e.g., `buckets/list-of-l.ist/index.html`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2281,6 +2281,7 @@ checksum = "2929e494b2280e1e18959bb2e121da03347ae896896fdfaceaab43c88a02803f"
 dependencies = [
  "memo-map",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ minify-html = "0"
 jluszcz_rust_utils = { git = "https://github.com//jluszcz/rust-utils" }
 lambda_runtime = "1"
 log = "0"
-minijinja = "2"
+minijinja = { version = "2", features = ["json"] }
 regex = "1"
 serde = "1"
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ ListOfLists generates a static website, hosted on AWS in an S3 bucket, from a JS
 ```json
 {
   "title": "The List",
+  "description": "An example list of lists",
   "lists": [
     {
       "title": "Letters",
@@ -59,6 +60,9 @@ ListOfLists generates a static website, hosted on AWS in an S3 bucket, from a JS
 }
 ```
 
+The optional top-level `description` is used for the page's meta and OpenGraph descriptions; it falls back to `title`
+when omitted.
+
 ### List Fields
 
 | Field        | Type   | Default  | Description                                               |
@@ -72,10 +76,12 @@ ListOfLists generates a static website, hosted on AWS in an S3 bucket, from a JS
 
 The generator rejects input that would produce a degenerate page:
 
-- The top-level `title` must be non-empty.
+- The top-level `title` must be non-empty, and `description` (if present) must be non-empty.
 - `lists` must contain at least one list.
 - Each list `title`, each item string, and each tooltip must be non-empty.
 - Duplicate items within a list are rejected unless `duplicates: true`.
+- Visible list titles must remain distinct after sanitization into HTML ids (e.g. `Foo Bar` and `Foo_Bar` collide),
+  and must contain at least one usable id character (`A-Z`, `a-z`, `0-9`, `_`).
 
 ### Footers
 

--- a/index.template
+++ b/index.template
@@ -1,16 +1,17 @@
 <!doctype html>
 <html lang="en">
 <head>
+    {%- set page_description = description if description else title %}
     <meta charset="utf-8">
-    <meta name="description" content="{{ title }}">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="description" content="{{ page_description }}">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#212529">
 
     <!-- Preconnect to external domains for performance -->
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
 
-    <link rel="preload" as="style" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous" onload="this.onload=null;this.rel='stylesheet'">
-    <noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous"></noscript>
+    <!-- The primary stylesheet loads synchronously: async-loading it would flash unstyled content -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
 
     {%- if footer %}
     {%- for import in footer['imports'] %}
@@ -23,7 +24,6 @@
 
     <style>
         :root {
-            --bs-dark: #212529;
             --hover-border-color: #6c757d;
         }
 
@@ -41,8 +41,8 @@
         }
 
         /* Better focus styles for accessibility */
-        .nav-link:focus {
-            outline: 2px solid #0d6efd;
+        .nav-link:focus-visible {
+            outline: 2px solid var(--bs-primary);
             outline-offset: 2px;
         }
 
@@ -66,30 +66,32 @@
     <link rel="icon" href="images/favicon.ico">
 
     <!-- Enhanced SEO and Social Media Meta Tags -->
+    <link rel="canonical" href="https://{{ site_url }}/">
     <meta property="og:title" content="{{ title }}">
-    <meta property="og:description" content="{{ title }}">
+    <meta property="og:description" content="{{ page_description }}">
     <meta property="og:type" content="website">
+    <meta property="og:url" content="https://{{ site_url }}/">
     <meta name="twitter:card" content="summary">
     <meta name="twitter:title" content="{{ title }}">
-    <meta name="twitter:description" content="{{ title }}">
+    <meta name="twitter:description" content="{{ page_description }}">
 
-    <!-- Structured Data -->
+    <!-- Structured Data: tojson handles JSON escaping; HTML-escaping would corrupt it here -->
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "WebPage",
-      "name": "{{ title }}",
-      "description": "{{ title }}",
+      "name": {{ title | tojson }},
+      "description": {{ page_description | tojson }},
       "mainEntity": {
         "@type": "ItemList",
-        "name": "{{ title }}",
-        "numberOfItems": {{ lists | length }}
+        "name": {{ title | tojson }},
+        "numberOfItems": {{ lists | rejectattr('hidden') | length }}
       }
     }
     </script>
 </head>
 <body class="d-flex flex-column min-vh-100">
-    <nav class="navbar navbar-expand-lg bg-dark navbar-dark sticky-top" role="navigation" aria-label="Main navigation">
+    <nav class="navbar navbar-expand-lg bg-dark navbar-dark sticky-top" aria-label="Main navigation">
         <div class="container-fluid">
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarContent" aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation menu">
                 <span class="navbar-toggler-icon"></span>
@@ -108,14 +110,14 @@
         </div>
     </nav>
 
-    <main class="tab-content pt-2" role="main" aria-label="List content">
+    <main class="tab-content pt-2" aria-label="List content">
     {%- for list_item in lists if not list_item['hidden'] %}
         <div class="tab-pane container-fluid {{ 'active' if loop.first else 'fade' }}" id="tab_{{ list_item['title'] | div_id_safe }}" role="tabpanel" aria-labelledby="nav-link-{{ list_item['title'] | div_id_safe }}">
             <h3>{{ list_item['title'] }}</h3>
             <ol>
             {%- for item in list_item['list'] %}
                 {%- if item is mapping %}
-                <li><span class="hover" data-bs-toggle="tooltip" data-bs-placement="right" title="{{ item['tooltip'] }}" aria-label="{{ item['item'] }}, {{ item['tooltip'] }}" role="button" tabindex="0">{{ item['item'] }}</span></li>
+                <li><span class="hover" data-bs-toggle="tooltip" data-bs-placement="right" title="{{ item['tooltip'] }}" tabindex="0">{{ item['item'] }}</span></li>
                 {%- else %}
                 <li>{{ item }}</li>
                 {%- endif %}
@@ -126,15 +128,15 @@
     </main>
 
     {%- if footer or footer_links %}
-    <footer class="footer bg-dark sticky-bottom mt-auto" role="contentinfo" aria-label="Site footer">
+    <footer class="footer bg-dark sticky-bottom mt-auto" aria-label="Site footer">
         <div class="container-fluid">
             {%- if footer %}
             {%- for link in footer['links'] %}
-            <a class="fs-4 me-3 link-light" href="{{ link.url | safe }}" {%- if link.title %} title="{{ link.title }}"{%- endif %} target="_blank"><i class="{{ link.icon }}"></i></a>
+            <a class="fs-4 me-3 link-light" href="{{ link.url }}" {%- if link.title %} title="{{ link.title }}"{%- endif %} target="_blank" rel="noopener noreferrer"><i class="{{ link.icon }}"></i></a>
             {%- endfor %}
             {%- elif footer_links %}
             {%- for link in footer_links %}
-            <a class="fs-4 me-3 link-light" href="{{ link.url | safe }}" {%- if link.title %} title="{{ link.title }}"{%- endif %} target="_blank"><i class="bi bi-{{ link.icon }}"></i></a>
+            <a class="fs-4 me-3 link-light" href="{{ link.url }}" {%- if link.title %} title="{{ link.title }}"{%- endif %} target="_blank" rel="noopener noreferrer"><i class="bi bi-{{ link.icon }}"></i></a>
             {%- endfor %}
             {%- endif %}
         </div>
@@ -145,46 +147,14 @@
     <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.min.js" integrity="sha384-G/EV+4j2dNv+tEPo3++6LCgdCROaejBqfUeNjuKAiuXbjrxilcCdDz6ZAVfHWe1Y" crossorigin="anonymous"></script>
 
     <script>
-        // Initialize tooltips with enhanced accessibility
-        document.addEventListener('DOMContentLoaded', function() {
-            try {
-                if (typeof bootstrap !== 'undefined' && bootstrap.Tooltip) {
-                    const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
-                    [...tooltipTriggerList].map((tooltipTriggerEl, index) => {
-                        try {
-                            // Create unique ID for tooltip
-                            const tooltipId = 'tooltip-' + Date.now() + '-' + index;
-
-                            // Initialize Bootstrap tooltip with accessibility options
-                            const tooltip = new bootstrap.Tooltip(tooltipTriggerEl, {
-                                boundary: 'viewport',
-                                fallbackPlacements: ['top', 'bottom', 'left']
-                            });
-
-                            // Enhanced accessibility: ensure aria-describedby is set when tooltip shows
-                            tooltipTriggerEl.addEventListener('shown.bs.tooltip', function() {
-                                const tooltipElement = document.querySelector('.tooltip[role="tooltip"]');
-                                if (tooltipElement && !tooltipElement.id) {
-                                    tooltipElement.id = tooltipId;
-                                    tooltipTriggerEl.setAttribute('aria-describedby', tooltipId);
-                                }
-                            });
-
-                            // Clean up aria-describedby when tooltip hides
-                            tooltipTriggerEl.addEventListener('hidden.bs.tooltip', function() {
-                                tooltipTriggerEl.removeAttribute('aria-describedby');
-                            });
-
-                            return tooltip;
-                        } catch (error) {
-                            console.warn('Failed to initialize tooltip:', error);
-                            return null;
-                        }
-                    });
-                }
-            } catch (error) {
-                console.warn('Bootstrap tooltips failed to initialize:', error);
-            }
+        // Bootstrap manages tooltip aria-describedby wiring itself
+        document.addEventListener('DOMContentLoaded', () => {
+            document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach((el) => {
+                new bootstrap.Tooltip(el, {
+                    boundary: 'viewport',
+                    fallbackPlacements: ['top', 'bottom', 'left']
+                });
+            });
         });
 
         // Enhance keyboard navigation for tabs

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -2,7 +2,7 @@ use crate::{ListOfLists, s3util};
 use anyhow::{Context, Result};
 use log::{debug, trace};
 use minify_html::Cfg;
-use minijinja::{Environment, Error, State};
+use minijinja::{Environment, Error, State, Value, context};
 use regex::Regex;
 use std::sync::LazyLock;
 use std::{
@@ -46,6 +46,14 @@ impl Io {
                 site_path: Path::new("buckets").join(site_url),
             },
         }
+    }
+
+    // The template is shared across sites, so any Io for the same generator
+    // bucket reads the same template.
+    pub async fn read_template(&self) -> Result<String> {
+        self.read(SITE_INDEX_TEMPLATE)
+            .await
+            .with_context(|| format!("read {SITE_INDEX_TEMPLATE}"))
     }
 
     async fn read(&self, target: &str) -> Result<String> {
@@ -93,31 +101,6 @@ impl Io {
     }
 }
 
-pub async fn read_template(
-    generator_bucket: &str,
-    s3_client: Option<&aws_sdk_s3::Client>,
-) -> Result<String> {
-    match s3_client {
-        Some(client) => {
-            let bytes = s3util::get(client, generator_bucket, SITE_INDEX_TEMPLATE)
-                .await
-                .with_context(|| format!("read {SITE_INDEX_TEMPLATE}"))?;
-            let s = str::from_utf8(&bytes)
-                .with_context(|| format!("{SITE_INDEX_TEMPLATE} is not UTF-8"))?;
-            Ok(s.to_string())
-        }
-        None => {
-            let path = Path::new("buckets")
-                .join(generator_bucket)
-                .join(SITE_INDEX_TEMPLATE);
-            debug!("Reading {path:?}");
-            fs::read_to_string(&path)
-                .await
-                .with_context(|| format!("read {path:?}"))
-        }
-    }
-}
-
 async fn read_list(io: &Io, site_url: &str) -> Result<ListOfLists> {
     let key = format!("{site_url}.json");
     let content = io.read(&key).await.with_context(|| format!("read {key}"))?;
@@ -131,10 +114,10 @@ async fn read_list(io: &Io, site_url: &str) -> Result<ListOfLists> {
 }
 
 fn div_id_safe(_: &State, value: String) -> Result<String, Error> {
-    Ok(inner_div_id_safe(value))
+    Ok(sanitized_div_id(value))
 }
 
-fn inner_div_id_safe<S>(value: S) -> String
+pub(crate) fn sanitized_div_id<S>(value: S) -> String
 where
     S: Into<String>,
 {
@@ -212,7 +195,7 @@ pub async fn render_site(
 
     debug!("Rendering {SITE_INDEX} for {site_url}");
     let site = template
-        .render(&list_of_lists)
+        .render(context! { site_url, ..Value::from_serialize(&list_of_lists) })
         .with_context(|| format!("render {SITE_INDEX} for {site_url}"))?;
     debug!("Rendered {SITE_INDEX} for {site_url}");
 
@@ -248,9 +231,9 @@ pub async fn update_site(
     s3_client: Option<aws_sdk_s3::Client>,
     minify: bool,
 ) -> Result<()> {
-    let template = read_template(&generator_bucket, s3_client.as_ref()).await?;
-    let env = build_environment(&template)?;
     let io = Io::new(site_url.clone(), generator_bucket, s3_client);
+    let template = io.read_template().await?;
+    let env = build_environment(&template)?;
     render_site(&io, &env, &site_url, minify).await
 }
 
@@ -260,11 +243,11 @@ mod test {
 
     #[test]
     fn test_div_id_safe() {
-        assert_eq!("foo_bar_baz", inner_div_id_safe("foo, bar, baz"));
-        assert_eq!("Foo_Bar_Baz", inner_div_id_safe("Foo, Bar, Baz"));
-        assert_eq!("foo_1234", inner_div_id_safe("foo 1234"));
-        assert_eq!("Foo_1234", inner_div_id_safe("Foo 1234"));
-        assert_eq!("1234", inner_div_id_safe("1234"));
+        assert_eq!("foo_bar_baz", sanitized_div_id("foo, bar, baz"));
+        assert_eq!("Foo_Bar_Baz", sanitized_div_id("Foo, Bar, Baz"));
+        assert_eq!("foo_1234", sanitized_div_id("foo 1234"));
+        assert_eq!("Foo_1234", sanitized_div_id("Foo 1234"));
+        assert_eq!("1234", sanitized_div_id("1234"));
     }
 
     #[test]

--- a/src/lambda.rs
+++ b/src/lambda.rs
@@ -72,19 +72,27 @@ async fn function(event: LambdaEvent<Value>) -> Result<Value, lambda_runtime::Er
         return Ok(json!({}));
     }
 
-    let template = generator::read_template(&generator_bucket, Some(&s3_client)).await?;
+    let ios: Vec<generator::Io> = site_urls
+        .iter()
+        .map(|site_url| {
+            generator::Io::new(
+                site_url.clone(),
+                generator_bucket.clone(),
+                Some(s3_client.clone()),
+            )
+        })
+        .collect();
+
+    // site_urls (and therefore ios) is non-empty here, and the template is
+    // shared, so read it through the first site's Io.
+    let template = ios[0].read_template().await?;
     let env = generator::build_environment(&template)?;
 
-    let render_futures = site_urls.iter().map(|site_url| {
-        let io = generator::Io::new(
-            site_url.clone(),
-            generator_bucket.clone(),
-            Some(s3_client.clone()),
-        );
+    let render_futures = site_urls.iter().zip(&ios).map(|(site_url, io)| {
         let env = &env;
         async move {
             info!("Updating {site_url}");
-            generator::render_site(&io, env, site_url, MINIFY).await
+            generator::render_site(io, env, site_url, MINIFY).await
         }
     });
     let render_results = futures::future::join_all(render_futures).await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use anyhow::{Result, anyhow};
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 pub mod generator;
 
@@ -13,6 +13,11 @@ pub const SITE_URL_VAR: &str = "LOL_SITE_URL";
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct ListOfLists {
     pub title: String,
+
+    // Used for the meta/OpenGraph descriptions; falls back to title in the template.
+    #[serde(default)]
+    pub description: Option<String>,
+
     pub lists: Vec<List>,
 
     #[serde(default, alias = "footerLinks")]
@@ -28,12 +33,37 @@ impl ListOfLists {
         if self.title.trim().is_empty() {
             return Err(anyhow!("ListOfLists title must not be empty"));
         }
+        if let Some(description) = &self.description
+            && description.trim().is_empty()
+        {
+            return Err(anyhow!("ListOfLists description must not be empty"));
+        }
         if self.lists.is_empty() {
             return Err(anyhow!("ListOfLists must contain at least one list"));
         }
         for l in &self.lists {
             l.validate()?;
         }
+
+        // Visible list titles become HTML ids after sanitization; collisions would
+        // produce duplicate ids and broken tab navigation.
+        let mut div_ids: HashMap<String, &str> = HashMap::new();
+        for l in self.lists.iter().filter(|l| !l.hidden) {
+            let div_id = generator::sanitized_div_id(l.title.as_str());
+            if div_id.is_empty() {
+                return Err(anyhow!(
+                    "List title {:?} contains no characters usable in an HTML id",
+                    l.title
+                ));
+            }
+            if let Some(existing) = div_ids.insert(div_id.clone(), l.title.as_str()) {
+                return Err(anyhow!(
+                    "List titles {existing:?} and {:?} both map to HTML id {div_id:?}",
+                    l.title
+                ));
+            }
+        }
+
         Ok(self)
     }
 }
@@ -47,7 +77,7 @@ pub struct List {
     pub hidden: bool,
 
     #[serde(default)]
-    duplicates: bool,
+    pub duplicates: bool,
 
     pub list: Vec<ListItem>,
 }
@@ -276,6 +306,7 @@ mod test {
         let list_of_lists = ListOfLists {
             title: "The List".to_string(),
             footer_links: vec![],
+            description: None,
             footer: None,
             lists: vec![
                 List::new("Letters", true, false, &["A", "B", "C"]),
@@ -318,6 +349,7 @@ mod test {
         let lol = ListOfLists {
             title: "  ".to_string(),
             footer_links: vec![],
+            description: None,
             footer: None,
             lists: vec![List::new("Letters", false, false, &["A"])],
         };
@@ -329,8 +361,63 @@ mod test {
         let lol = ListOfLists {
             title: "The List".to_string(),
             footer_links: vec![],
+            description: None,
             footer: None,
             lists: vec![],
+        };
+        assert!(lol.validate().is_err());
+    }
+
+    #[test]
+    fn test_validation_rejects_blank_description() {
+        let lol = ListOfLists {
+            title: "The List".to_string(),
+            description: Some("  ".to_string()),
+            footer_links: vec![],
+            footer: None,
+            lists: vec![List::new("Letters", false, false, &["A"])],
+        };
+        assert!(lol.validate().is_err());
+    }
+
+    #[test]
+    fn test_validation_rejects_colliding_div_ids() {
+        let lol = ListOfLists {
+            title: "The List".to_string(),
+            description: None,
+            footer_links: vec![],
+            footer: None,
+            lists: vec![
+                List::new("Foo Bar", false, false, &["A"]),
+                List::new("Foo_Bar", false, false, &["B"]),
+            ],
+        };
+        assert!(lol.validate().is_err());
+    }
+
+    #[test]
+    fn test_validation_allows_hidden_div_id_collision() {
+        let lol = ListOfLists {
+            title: "The List".to_string(),
+            description: None,
+            footer_links: vec![],
+            footer: None,
+            lists: vec![
+                List::new("Foo Bar", false, false, &["A"]),
+                List::new("Foo_Bar", true, false, &["B"]),
+            ],
+        };
+        assert!(lol.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validation_rejects_unusable_div_id() {
+        let lol = ListOfLists {
+            title: "The List".to_string(),
+            description: None,
+            footer_links: vec![],
+            footer: None,
+            lists: vec![List::new("!!!", false, false, &["A"])],
         };
         assert!(lol.validate().is_err());
     }
@@ -374,6 +461,7 @@ mod test {
         let list_of_lists = ListOfLists {
             title: "The List".to_string(),
             footer_links: vec![],
+            description: None,
             footer: Some(Footer {
                 imports: vec!["https://import.js".to_string()],
                 links: vec![FooterItem {
@@ -402,6 +490,7 @@ mod test {
                 icon: "github".to_string(),
                 title: None,
             }],
+            description: None,
             footer: None,
             lists: vec![List::new("Letters", true, false, &["A", "B", "C"])],
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ struct Args {
 
 fn parse_args() -> Args {
     let matches = Command::new("ListOfLists-Generator")
-        .version("0.1")
+        .version(env!("CARGO_PKG_VERSION"))
         .author("Jacob Luszcz")
         .arg(
             Arg::new("site-url")


### PR DESCRIPTION
- Emit JSON-LD via tojson (HTML escaping corrupted it) and count only visible lists; requires minijinja's json feature
- Load the primary stylesheet synchronously to avoid a flash of unstyled content
- Add rel="noopener noreferrer" to footer links; drop `| safe` on URLs
- Replace custom tooltip aria wiring with Bootstrap's built-in handling; drop misleading role="button" and redundant landmark roles
- Drop obsolete shrink-to-fit and no-op --bs-dark; use :focus-visible
- Add optional top-level `description` (meta/OpenGraph) and pass site_url to the template for canonical/og:url
- Validate that visible list titles map to distinct, non-empty HTML ids
- Consolidate template reading into Io::read_template; make List.duplicates pub; CLI version from CARGO_PKG_VERSION