### PR TITLE
chore: rename CI workflow to ci.yml and normalize build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Build and Deploy
+name: CI
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
       - main
 
     paths:
-      - '.github/workflows/build-and-deploy.yml'
+      - '.github/workflows/ci.yml'
       - 'Cargo**'
       - 'src/**/*.rs'
 
@@ -18,7 +18,8 @@ env:
   PROJECT: list-of-lists
 
 jobs:
-  build-and-package:
+  build:
+    name: Build, Test & Lint
     runs-on: ubuntu-24.04-arm
 
     env:
@@ -65,7 +66,7 @@ jobs:
           retention-days: 1
 
   deploy:
-    needs: build-and-package
+    needs: build
 
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ ListOfLists generates a static website, hosted on AWS in an S3 bucket, from a JS
 
 ## Status
 
-[![.github/workflows/build-and-deploy.yml](https://github.com/jluszcz/ListOfLists-rs/actions/workflows/build-and-deploy.yml/badge.svg)](https://github.com/jluszcz/ListOfLists-rs/actions/workflows/build-and-deploy.yml)
+[![.github/workflows/ci.yml](https://github.com/jluszcz/ListOfLists-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/jluszcz/ListOfLists-rs/actions/workflows/ci.yml)
 
 [![.github/workflows/update-index-template.yml](https://github.com/jluszcz/ListOfLists-rs/actions/workflows/update-index-template.yml/badge.svg)](https://github.com/jluszcz/ListOfLists-rs/actions/workflows/update-index-template.yml)
 


### PR DESCRIPTION
Rename build-and-deploy.yml to ci.yml, rename the build-and-package job to build (with an explicit "Build, Test & Lint" name), and update the self-referential path filter to match.