### PR TITLE
chore(cli): infer long args and lint test code in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           sudo apt-get install -y musl-tools
           rustup target add ${{ env.BUILD_TARGET }}
           rustup update
-          rustup component add clippy
+          rustup component add clippy rustfmt
 
       - name: Dump Toolchain Info
         run: |
@@ -47,8 +47,11 @@ jobs:
       - name: Test
         run: cargo test --target ${{ env.BUILD_TARGET }}
 
+      - name: Format
+        run: cargo fmt --check
+
       - name: Lint
-        run: cargo clippy --target ${{ env.BUILD_TARGET }} -- -D warnings
+        run: cargo clippy --target ${{ env.BUILD_TARGET }} --all-targets -- -D warnings
 
       - name: Package
         if: github.event_name == 'push'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - `cargo build` - Build the project
 - `cargo fmt` - Format the source code
+- `cargo fmt --check` - Check formatting (same as CI)
 - `cargo test` - Run all tests
 - `cargo check` - Check for compilation errors without building
-- `cargo clippy -- -D warnings` - Run Rust linter for code quality checks
+- `cargo clippy --all-targets -- -D warnings` - Run Rust linter for code quality checks (same as CI)
 
 ### Running the Application
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ fn parse_args() -> Args {
     let matches = Command::new("ListOfLists-Generator")
         .version(env!("CARGO_PKG_VERSION"))
         .author("Jacob Luszcz")
+        .infer_long_args(true)
         .arg(
             Arg::new("site-url")
                 .short('u')


### PR DESCRIPTION
Add infer_long_args to the clap Command so unambiguous long-flag prefixes work, add a Format (cargo fmt --check) CI step before Lint, lint test code (--all-targets), and sync CLAUDE.md commands with CI.