### PR TITLE
fix(ci): correct deploy bucket region interpolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,5 +96,5 @@ jobs:
         if: github.event_name == 'push'
         env:
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-          AWS_BUCKET: code-${{ secrets.AWS_ACCOUNT_ID }}-${{ env.AWS_DEFAULT_REGION }}-an
+          AWS_BUCKET: code-${{ secrets.AWS_ACCOUNT_ID }}-${{ secrets.AWS_DEFAULT_REGION }}-an
         run: aws s3 cp ${{ env.PROJECT }}.zip s3://${AWS_BUCKET}/


### PR DESCRIPTION
The deploy job's `AWS_BUCKET` used `${{ env.AWS_DEFAULT_REGION }}`, but the `env` context cannot reference a sibling `env` key defined in the same map — it evaluated empty and produced a malformed bucket name (`code-<account>--an`). Switched to `${{ secrets.AWS_DEFAULT_REGION }}`, matching the `aws-region:` line above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)