### PR TITLE
Use shared CI + lambda-package + deploy-lambda workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,90 +17,29 @@ on:
 permissions:
   contents: read
 
-env:
-  PROJECT: list-of-lists
-
 jobs:
-  build:
-    name: Build, Test & Lint
-    runs-on: ubuntu-24.04-arm
+  ci:
+    uses: jluszcz/github-utils/.github/workflows/rust-ci.yml@v1
+    with:
+      runs-on: ubuntu-24.04-arm
+      target: aarch64-unknown-linux-musl
 
-    env:
-      BUILD_TARGET: aarch64-unknown-linux-musl
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Update and Configure Rust
-        run: |
-          sudo apt-get install -y musl-tools
-          rustup target add ${{ env.BUILD_TARGET }}
-          rustup update
-          rustup component add clippy rustfmt
-
-      - name: Dump Toolchain Info
-        run: |
-          cargo --version --verbose
-          rustc --version
-          cargo clippy --version
-
-      - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
-
-      - name: Build
-        run: cargo build --target ${{ env.BUILD_TARGET }}
-
-      - name: Test
-        run: cargo test --target ${{ env.BUILD_TARGET }}
-
-      - name: Format
-        run: cargo fmt --check
-
-      - name: Lint
-        run: cargo clippy --target ${{ env.BUILD_TARGET }} --all-targets -- -D warnings
-
-      - name: Package
-        if: github.event_name == 'push'
-        run: |
-          cargo build --release --target ${{ env.BUILD_TARGET }}
-          cp target/${{ env.BUILD_TARGET }}/release/lambda bootstrap
-          zip -j ${{ env.PROJECT }}.zip bootstrap
-
-      - name: Upload Package
-        if: github.event_name == 'push'
-        uses: actions/upload-artifact@v7
-        with:
-          name: package
-          path: ${{ env.PROJECT }}.zip
-          retention-days: 1
+  package:
+    needs: ci
+    if: github.event_name == 'push'
+    uses: jluszcz/github-utils/.github/workflows/lambda-package.yml@v1
+    with:
+      project: list-of-lists
 
   deploy:
-    needs: build
-
-    runs-on: ubuntu-latest
-
+    needs: package
+    if: github.event_name == 'push'
     permissions:
       id-token: write
       contents: read
-
-    steps:
-      - name: Download Package
-        if: github.event_name == 'push'
-        uses: actions/download-artifact@v8
-        with:
-          name: package
-
-      - name: Configure AWS Credentials
-        if: github.event_name == 'push'
-        uses: aws-actions/configure-aws-credentials@v6.2.1
-        with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ env.PROJECT }}.github-deploy
-          role-session-name: github-deploy
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-
-      - name: Deploy Lambda
-        if: github.event_name == 'push'
-        env:
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-          AWS_BUCKET: code-${{ secrets.AWS_ACCOUNT_ID }}-${{ secrets.AWS_DEFAULT_REGION }}-an
-        run: aws s3 cp ${{ env.PROJECT }}.zip s3://${AWS_BUCKET}/
+    uses: jluszcz/github-utils/.github/workflows/deploy-lambda.yml@v1
+    with:
+      aws-region: us-east-2
+      project: list-of-lists
+    secrets:
+      aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}


### PR DESCRIPTION
Lambda deploy migration (single region us-east-2). **No IAM change** — `list-of-lists.github-deploy` already exists and matches the standardized `-deploy` convention.

- `ci`/`package`/`deploy` → shared workflows `@v1`
- Region hardcoded to `us-east-2` (replaces the `AWS_DEFAULT_REGION` secret) — please confirm that secret was `us-east-2` (the Terraform backend is us-east-2, which corroborates it)
- Required check renamed to `ci / Build, Test & Lint`

No `terraform apply` needed before merge (role already exists). Just merge and the post-merge deploy assumes `list-of-lists.github-deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)