### PR TITLE
Hardcode us-east-2 in update-index-template

### DIFF
--- a/.github/workflows/update-index-template.yml
+++ b/.github/workflows/update-index-template.yml
@@ -25,10 +25,10 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/list-of-lists.github-update
           role-session-name: github-upload
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+          aws-region: us-east-2
 
       - name: Upload to S3
         env:
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-          AWS_BUCKET: list-of-lists-${{ secrets.AWS_ACCOUNT_ID }}-${{ secrets.AWS_DEFAULT_REGION }}-an
+          AWS_DEFAULT_REGION: us-east-2
+          AWS_BUCKET: list-of-lists-${{ secrets.AWS_ACCOUNT_ID }}-us-east-2-an
         run: aws s3 cp index.template s3://${AWS_BUCKET}/

--- a/.github/workflows/update-index-template.yml
+++ b/.github/workflows/update-index-template.yml
@@ -31,4 +31,4 @@ jobs:
         env:
           AWS_DEFAULT_REGION: us-east-2
           AWS_BUCKET: list-of-lists-${{ secrets.AWS_ACCOUNT_ID }}-us-east-2-an
-        run: aws s3 cp index.template s3://${AWS_BUCKET}/
+        run: aws s3 cp index.template "s3://${AWS_BUCKET}/"

--- a/.github/workflows/update-index-template.yml
+++ b/.github/workflows/update-index-template.yml
@@ -29,6 +29,5 @@ jobs:
 
       - name: Upload to S3
         env:
-          AWS_DEFAULT_REGION: us-east-2
-          AWS_BUCKET: list-of-lists-${{ secrets.AWS_ACCOUNT_ID }}-us-east-2-an
-        run: aws s3 cp index.template "s3://${AWS_BUCKET}/"
+          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+        run: aws s3 cp index.template "s3://list-of-lists-${AWS_ACCOUNT_ID}-${AWS_REGION}-an/"


### PR DESCRIPTION
Replaces the three `secrets.AWS_DEFAULT_REGION` references in `update-index-template.yml` with `us-east-2` (matching `ci.yml`, which was hardcoded during the Lambda deploy migration).

This removes the last use of the `AWS_DEFAULT_REGION` secret in the repo, so it can be deleted afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)