### PR TITLE
chore(deps): pin 0.x dependencies to their minor version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,10 +8,24 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - `cargo build` - Build the project
 - `cargo fmt` - Format the source code
-- `cargo fmt --check` - Check formatting (same as CI)
+- `cargo fmt --check` - Check formatting
 - `cargo test` - Run all tests
 - `cargo check` - Check for compilation errors without building
-- `cargo clippy --all-targets -- -D warnings` - Run Rust linter for code quality checks (same as CI)
+- `cargo clippy --all-targets -- -D warnings` - Run Rust linter for code quality checks
+- `pre-commit run --all-files` - Run the configured hooks (includes `cargo fmt --check`)
+
+### CI
+
+`.github/workflows/ci.yml` is a thin caller of `jluszcz/github-utils/.github/workflows/rust-ci.yml@v1`, which runs
+build, test, `cargo fmt --check`, and `cargo clippy --all-targets -- -D warnings` on `ubuntu-24.04-arm` against the
+`aarch64-unknown-linux-musl` target. The steps live in that shared workflow, not in this repo. On a push to `main`,
+CI additionally packages and deploys the Lambda to `us-east-2` via the shared `lambda-package` and `deploy-lambda`
+workflows.
+
+### Dependency Versioning
+
+Pin 0.x dependencies to their **minor** version (`futures = "0.3"`, not `futures = "0"`). For 0.x crates the minor
+version is the breaking axis, so a bare `"0"` resolves to `<1.0.0` and lets breaking releases through silently.
 
 ### Running the Application
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ aws-sdk-s3 = { version = "1", features = ["behavior-version-latest"] }
 aws_lambda_events = "1"
 bytes = "1"
 clap = { version = "4", features = ["derive", "env"] }
-futures = "0"
-minify-html = "0"
+futures = "0.3"
+minify-html = "0.16"
 jluszcz_rust_utils = { git = "https://github.com//jluszcz/rust-utils" }
 lambda_runtime = "1"
-log = "0"
+log = "0.4"
 minijinja = { version = "2", features = ["json"] }
 regex = "1"
 serde = "1"


### PR DESCRIPTION
For 0.x crates the minor version is the breaking axis, so a bare `"0"` requirement resolves to `<1.0.0` and lets breaking releases through as if they were compatible.

Pins (`futures = "0.3"`, `minify-html = "0.16"`, `log = "0.4"`) match the versions already in `Cargo.lock`, so dependency resolution is unchanged.

**Worth knowing:** `minify-html` is locked at 0.16.5 while 0.18.1 is available — the repo was silently two minors behind and invisible to Dependabot. Pinning to `0.16` is deliberate: that upgrade now surfaces as an explicit PR that can be reviewed for breakage, rather than landing on the next `cargo update`.

Also corrects `CLAUDE.md`, which labelled the plain `cargo fmt --check` / `cargo clippy` commands "(same as CI)". CI is a thin caller of the shared `rust-ci` reusable workflow and runs them on `ubuntu-24.04-arm` against `aarch64-unknown-linux-musl`.

## Verification

- `cargo fmt --check` — pass
- `cargo clippy --all-targets --all-features -- -D warnings` — pass
- `cargo test` — 24/24 pass
- `Cargo.lock` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)