### PR TITLE
test: render index.template in CI so a broken one cannot ship

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
       - '.github/workflows/ci.yml'
       - 'Cargo**'
       - 'src/**/*.rs'
+      # The template is rendered by a test, and a broken one breaks every site
+      # the generator produces.
+      - 'index.template'
 
   pull_request:
     branches:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,11 @@ has two main execution modes:
 - Iterates over non-hidden lists to build Bootstrap tab navigation and list content
 - Supports two item types: plain strings and tooltip objects (`{ item, tooltip }`)
 - When running locally, the generated `index.html` is written to `buckets/{site_url}/index.html` (e.g., `buckets/list-of-l.ist/index.html`)
+- **The template ships as its own S3 object** (uploaded by `.github/workflows/update-index-template.yml` when it
+  changes), so it is not compiled into the binary and nothing else in the build parses it. `cargo test` renders it
+  via `include_str!` against sample data for exactly that reason — a template that fails to compile or render breaks
+  *every* site the generator produces, and those tests are the only thing standing in front of that. `index.template`
+  is in CI's push paths so a template-only change still runs them.
 
 **Executables**
 

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -313,4 +313,70 @@ mod test {
         let input = r#"<link rel="icon" href="favicon.ico">"#;
         assert_eq!(input, inner_optimize_import(input));
     }
+
+    // The template ships as a separate S3 object rather than being compiled in,
+    // so nothing else in the build ever parses it. Uploading a broken one breaks
+    // every site the generator renders.
+    const EXAMPLE_LIST: &str = r#"
+    {
+        "title": "The List",
+        "description": "A list of lists",
+        "lists": [
+            {
+                "title": "Letters",
+                "hidden": true,
+                "list": ["A", "B", "C"]
+            },
+            {
+                "title": "Numbers",
+                "list": ["1", "2", {"item": "3", "tooltip": "three"}]
+            }
+        ],
+        "footerLinks": [{"url": "https://example.com", "icon": "bi-house", "title": "Home"}]
+    }
+    "#;
+
+    fn render_index_template(list_of_lists: &ListOfLists) -> String {
+        let template = include_str!("../index.template");
+        let env = build_environment(template).expect("index.template must compile");
+        env.get_template(SITE_INDEX)
+            .expect("compiled template must be registered")
+            .render(context! { site_url => "example.com", ..Value::from_serialize(list_of_lists) })
+            .expect("index.template must render")
+    }
+
+    #[test]
+    fn index_template_renders_the_site() {
+        let list_of_lists: ListOfLists =
+            serde_json::from_str(EXAMPLE_LIST).expect("example list must deserialize");
+
+        let rendered = render_index_template(&list_of_lists);
+
+        assert!(rendered.contains("<html"), "{rendered}");
+        assert!(rendered.contains("The List"), "{rendered}");
+        assert!(rendered.contains("A list of lists"), "{rendered}");
+        assert!(rendered.contains("Numbers"), "{rendered}");
+        assert!(
+            rendered.contains("three"),
+            "tooltip should render: {rendered}"
+        );
+    }
+
+    #[test]
+    fn index_template_renders_a_minimal_site() {
+        // No description, no footer, no footer links — every optional branch skipped.
+        let list_of_lists: ListOfLists = serde_json::from_str(
+            r#"{"title": "Bare", "lists": [{"title": "Only", "list": ["x"]}]}"#,
+        )
+        .expect("minimal list must deserialize");
+
+        let rendered = render_index_template(&list_of_lists);
+
+        assert!(rendered.contains("Bare"), "{rendered}");
+        // description falls back to title for the meta tags
+        assert!(
+            rendered.contains(r#"name="description" content="Bare""#),
+            "{rendered}"
+        );
+    }
 }


### PR DESCRIPTION
Closes the ListOfLists-rs half of theme 4 from the portfolio review.

### A correction to the finding first

The review said a template-only merge to `main` "runs no checks at all." That is true of `ci.yml`, but there *is* a dedicated `update-index-template.yml` that triggers on `index.template` and uploads it to S3 — so the change does get deployed. The gap is narrower and worse than "nothing runs": **the template is uploaded without anything ever having parsed it.**

It ships as its own S3 object rather than being compiled into the binary, so `cargo build` and `cargo test` never touched it. A template that fails to compile or render breaks *every* site the generator produces, and nothing in the repo would have caught it.

### The fix

Two tests render the real template via `include_str!` against sample data — a full site (description, tooltips, footer links) and a minimal one that skips every optional branch. `index.template` is also added to CI's push paths; the `pull_request` trigger has no path filter, so template-only PRs already ran CI, and this makes the post-merge run consistent.

Since the ruleset requires `ci / Build, Test & Lint` and a PR to merge, a broken template now cannot reach `main` at all.

### Verification

`cargo test` (26, up from 24), `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `actionlint` all pass.

I checked the tests are real rather than vacuous: corrupting a single `{%- if footer %}` tag in the template makes both fail with `syntax error: unexpected '%' (in index.html:17)`. Restored before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)