### PR TITLE
feat(iam): let the deploy role update the function directly

### DIFF
--- a/shared/main.tf
+++ b/shared/main.tf
@@ -260,6 +260,12 @@ data "aws_iam_policy_document" "github_deploy" {
     actions   = ["s3:PutObject"]
     resources = ["${data.aws_s3_bucket.code_bucket.arn}/list-of-lists.zip"]
   }
+
+  # GetFunction backs the `aws lambda wait function-updated-v2` in deploy-lambda.yml.
+  statement {
+    actions   = ["lambda:UpdateFunctionCode", "lambda:GetFunction"]
+    resources = [aws_lambda_function.lambda.arn]
+  }
 }
 
 resource "aws_iam_policy" "github_deploy" {


### PR DESCRIPTION
Grant the deploy role Lambda UpdateFunctionCode and GetFunction permissions on the function resource.

The shared deploy-lambda.yml workflow is moving from "upload and let LambdUpdate notice" to calling UpdateFunctionCode directly. GetFunction backs the waiter that confirms the new code went active.

Note: this permission is not used until this repo's workflow pin moves to @v2 in a later task.