### PR TITLE
ci: update the function from CI instead of via LambdUpdate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    uses: jluszcz/github-utils/.github/workflows/deploy-lambda.yml@v1
+    uses: jluszcz/github-utils/.github/workflows/deploy-lambda.yml@v2
     with:
       aws-region: us-east-2
       project: list-of-lists


### PR DESCRIPTION
This repo moves to the workflow that updates the function itself.
The IAM grant it needs is already applied.