### PR TITLE
fix(iam): grant the deploy role GetObject on the artifact

### DIFF
--- a/shared/main.tf
+++ b/shared/main.tf
@@ -257,7 +257,9 @@ resource "aws_iam_role_policy_attachment" "github_update_template" {
 
 data "aws_iam_policy_document" "github_deploy" {
   statement {
-    actions   = ["s3:PutObject"]
+    # GetObject too: update-function-code makes Lambda fetch the artifact with
+    # the caller's credentials, not the function's execution role.
+    actions   = ["s3:PutObject", "s3:GetObject"]
     resources = ["${data.aws_s3_bucket.code_bucket.arn}/list-of-lists.zip"]
   }
 


### PR DESCRIPTION
The shared workflow now uses update-function-code with S3 bucket/key, which makes Lambda fetch the artifact using the caller's credentials. This requires s3:GetObject in addition to s3:PutObject in the deploy role's policy.

A sibling repo's deployment failed with AccessDenied on GetObject; this repo has the same gap.